### PR TITLE
Potential fix for code scanning alert no. 8: Missing CSRF middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const bcrypt = require('bcrypt');
 const session = require('express-session')
 const path = require('path');
 const querystring = require('querystring');
+const csrf = require('lusca').csrf;
 
 const db = new sqlite3.Database('main.db', err => {
     if (err) {
@@ -2866,6 +2867,8 @@ app.use(session({
     resave: false,
     saveUninitialized: true
 }));
+
+app.use(csrf());
 
 const protect = (req, res, next) => {
     if (req.session && req.session.adminId) {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "pm2": "^6.0.14",
     "sqlite3": "^6.0.1",
     "unique-username-generator": "^1.5.1",
-    "uuid": "^13.0.0"
+    "uuid": "^13.0.0",
+    "lusca": "^1.7.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Mr-milky-way/Custom-DRL-Server/security/code-scanning/8](https://github.com/Mr-milky-way/Custom-DRL-Server/security/code-scanning/8)

In general, the fix is to introduce CSRF protection middleware for routes that depend on cookie-based authentication and perform sensitive actions. A standard approach in Express is to use a middleware like `lusca.csrf` (as suggested) or `csurf`. This middleware issues a per-session token, requires that token to be sent with each state-changing request (e.g., POST), and rejects requests missing or having an invalid token. Front-end code must then include that token (for example, from a hidden form field or header) in each POST/PUT/DELETE request.

For this specific code, the least intrusive fix that preserves existing behavior is to:  
1) Import `csrf` from `lusca`.  
2) Mount `app.use(csrf())` after `app.use(session(...))` so that the CSRF middleware can use the session.  
3) Ensure that the admin POST routes, including `/adminlogin` and `/admin/changepassword`, are protected by this CSRF middleware. Since they already use `express.urlencoded`, we can simply rely on the default lusca behavior (which checks common locations for the token) and leave the route logic unchanged. This will require that any HTML forms or AJAX clients sending requests to these endpoints include the CSRF token; that part is outside the shown snippet, so we only wire in the middleware here.

Concretely in `index.js`:
- Add `const csrf = require('lusca').csrf;` alongside the other `require` statements at the top.
- After `app.use(session({ ... }))` (line 2864–2868), add `app.use(csrf());`. This protects subsequent routes, including `/adminlogin` and `/admin/changepassword`, without changing their implementations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
