### PR TITLE
Potential fix for code scanning alert no. 9: Clear text transmission of sensitive cookie

### DIFF
--- a/index.js
+++ b/index.js
@@ -2865,7 +2865,12 @@ function decryptDRL(token, keyString, ivString) {
 app.use(session({
     secret: process.env.SESSION_SECRET || 'secretKey',
     resave: false,
-    saveUninitialized: true
+    saveUninitialized: true,
+    cookie: {
+        secure: process.env.NODE_ENV === 'production',
+        httpOnly: true,
+        sameSite: 'lax'
+    }
 }));
 
 app.use(csrf());


### PR DESCRIPTION
Potential fix for [https://github.com/Mr-milky-way/Custom-DRL-Server/security/code-scanning/9](https://github.com/Mr-milky-way/Custom-DRL-Server/security/code-scanning/9)

In general, to fix this type of issue with `express-session`, you must explicitly configure the `cookie` option so that the session cookie is marked `secure` (and ideally `httpOnly` and with a restrictive `sameSite` policy). For applications behind HTTPS, `cookie.secure: true` ensures browsers only send the cookie over HTTPS, preventing clear-text transmission. Because development environments often still use HTTP, a common and safe pattern is to set `cookie.secure` based on `NODE_ENV` (or another environment variable), so production enforces HTTPS while development continues to work.

The best fix here is to extend the existing `session({...})` configuration at lines 2865–2869 to include a `cookie` object configuring `secure`, `httpOnly`, and `sameSite`. To avoid changing runtime behavior in local development, we can set `secure` dynamically: `secure: process.env.NODE_ENV === 'production'`. No changes are needed elsewhere in the file; we are only tightening cookie attributes. No additional imports or helper methods are required; `express-session` already accepts this configuration.

Concretely, in `index.js`, modify the `app.use(session({ ... }))` block to:

- Add a `cookie` property with:
  - `secure: process.env.NODE_ENV === 'production'`
  - `httpOnly: true`
  - `sameSite: 'lax'` (good default that doesn’t break most flows)

This keeps existing behavior for non-production environments while enforcing SSL for the session cookie in production, addressing the CodeQL finding without altering application logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
