### PR TITLE
Potential fix for code scanning alert no. 19: Type confusion through parameter tampering

### DIFF
--- a/index.js
+++ b/index.js
@@ -1654,18 +1654,24 @@ app.get('/social/profile/', badTokenAuthv2, (req, res) => {
     console.log("social profile header for:", req.query);
     const uid = req.uid
     let payload = []
-    console.log(req.query['epic-ids'])
-    if (req.query['epic-ids']) {
+    const epicIds = Array.isArray(req.query['epic-ids'])
+        ? req.query['epic-ids']
+        : (typeof req.query['epic-ids'] === 'string' ? [req.query['epic-ids']] : []);
+    const steamIds = Array.isArray(req.query['steam-ids'])
+        ? req.query['steam-ids']
+        : (typeof req.query['steam-ids'] === 'string' ? [req.query['steam-ids']] : []);
+    console.log(epicIds)
+    if (epicIds.length > 0) {
         let marks = []
-        for (let i = 0; i < req.query['epic-ids'].length; i++) {
+        for (let i = 0; i < epicIds.length; i++) {
             marks.push("?")
         }
-        db.all(`SELECT * FROM profilestatemodel WHERE player_id IN (${marks.join(',')})`, [req.query['epic-ids']], (err, rows) => {
+        db.all(`SELECT * FROM profilestatemodel WHERE player_id IN (${marks.join(',')})`, [...epicIds], (err, rows) => {
             if (err || rows.length === 0) {
                 console.log("epic_id faild with:", err)
             } else {
-                for (let i = 0; i < req.query['epic-ids'].length; i++) {
-                    if (rows[i].player_id === req.query['epic-ids'][i]) {
+                for (let i = 0; i < epicIds.length; i++) {
+                    if (rows[i].player_id === epicIds[i]) {
                         payload.push({
                             "platform-id": "epic-id",
                             "player-id": rows[i].player_id,
@@ -1684,17 +1690,17 @@ app.get('/social/profile/', badTokenAuthv2, (req, res) => {
             }
         });
     }
-    if (req.query['steam-ids']) {
+    if (steamIds.length > 0) {
         let marks = []
-        for (let i = 0; i < req.query['steam-ids'].length; i++) {
+        for (let i = 0; i < steamIds.length; i++) {
             marks.push("?")
         }
-        db.all(`SELECT * FROM profilestatemodel WHERE steam_id IN (${marks.join(',')})`, [...req.query['steam-ids']], (err, rows) => {
+        db.all(`SELECT * FROM profilestatemodel WHERE steam_id IN (${marks.join(',')})`, [...steamIds], (err, rows) => {
             if (err || rows.length === 0) {
                 console.log("steam_id faild with:", err)
             } else {
-                for (let i = 0; i < req.query['steam-ids'].length; i++) {
-                    if (rows[i].steam_id === req.query['steam-ids'][i]) {
+                for (let i = 0; i < steamIds.length; i++) {
+                    if (rows[i].steam_id === steamIds[i]) {
                         payload.push({
                             "platform-id": "steam-id",
                             "player-id": rows[i].player_id,


### PR DESCRIPTION
Potential fix for [https://github.com/Mr-milky-way/Drone-Racing-League-Community-Server/security/code-scanning/19](https://github.com/Mr-milky-way/Drone-Racing-League-Community-Server/security/code-scanning/19)

General fix: normalize and validate user-controlled query params before using them in sanitizer/business logic. For this route, coerce `steam-ids` and `epic-ids` into arrays of strings (or reject invalid types) so later code is type-stable.

Best fix here without changing intended functionality:
- In `index.js` inside `/social/profile/` handler, introduce local normalized arrays:
  - `epicIds`: `[]` if missing, `[value]` if string, unchanged if array, otherwise `[]`.
  - `steamIds`: same pattern.
- Replace all downstream uses of `req.query['epic-ids']` / `req.query['steam-ids']` in loops, SQL bindings, and comparisons with `epicIds` / `steamIds`.
- Keep existing query behavior (single id still works), but remove type confusion risk and incorrect string-index behavior.
- Also correct the epic SQL binding from `[req.query['epic-ids']]` to `[...]`-style array binding using normalized array (this is a correctness fix aligned with intended logic).

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
